### PR TITLE
Added multiline comment syntax to language file

### DIFF
--- a/Stylus.tmLanguage
+++ b/Stylus.tmLanguage
@@ -26,6 +26,22 @@
 			<string>comment.line.stylus</string>
 		</dict>
 		<dict>
+			<key>begin</key>
+			<string>/\*</string>
+			<key>captures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.comment.stylus</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>\*/</string>
+			<key>name</key>
+			<string>comment.block.stylus</string>
+		</dict>
+		<dict>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -178,7 +194,7 @@
 			<key>name</key>
 			<string>comment.block.js</string>
 		</dict>
-		
+
     <dict>
       <key>comment</key>
       <string>http://www.w3.org/TR/CSS21/syndata.html#value-def-color</string>


### PR DESCRIPTION
---

Syntax file didn't recognize multiple line comments using the /\* …comment… */ syntax. Added comment.block.stylus to Stylus.tmLanguage syntax file to rectify.
