### PR TITLE
Improvements, fixes

### DIFF
--- a/Stylus.tmLanguage
+++ b/Stylus.tmLanguage
@@ -51,7 +51,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(^[-a-zA-Z_][-\w]*)?(\()</string>
+			<string>(^[-a-zA-Z_][-\w]*)?(?=\()</string>
 			<key>name</key>
 			<string>meta.function.stylus</string>
 		</dict>
@@ -83,15 +83,33 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(.*)(?=\s*=)</string>
+			<string>\$?\b([\$\w\-]+)(?=\s*[:\?]?=)</string>
 			<key>name</key>
-			<string>variable.language.stylus</string>
+			<string>variable.assignment.stylus</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>@([-\w]+)</string>
-			<key>name</key>
-			<string>keyword.stylus</string>
+			<string>^\s*(\@[-\w]+)</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.at-rule.stylus</string>
+				</dict>
+			</dict>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>(\@)(?=[-\w])</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>variable.punctuation.property.stylus</string>
+				</dict>
+			</dict>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -213,13 +231,19 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(\b|\s)(!important|for|in|return|true|false|null|if|else|unless|return)\b</string>
+			<string>\b(true|false|defined|null)\b</string>
+			<key>name</key>
+			<string>constant.language.stylus</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>(\b|\s)(!important|for|in|return|if|else|unless|return)\b</string>
 			<key>name</key>
 			<string>keyword.control.stylus</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>((?:!|~|\+|-|(?:\*)?\*|\/|%|(?:\.)\.\.|&lt;|&gt;|(?:=|:|\?|\+|-|\*|\/|%|&lt;|&gt;)?=|!=)|\b(?:in|is(?:nt)?|not)\b)</string>
+			<string>((?:\?|!|~|\+|-|(?:\*)?\*|\/|%|(?:\.)\.\.|&lt;|&gt;|(?:=|:|\?|\+|-|\*|\/|%|&lt;|&gt;)?=|!=)|\b(?:in|is(?:nt)?|not)\b)</string>
 			<key>name</key>
 			<string>keyword.operator.stylus</string>
 		</dict>
@@ -305,7 +329,13 @@
 			<key>match</key>
 			<string>\{|\}</string>
 			<key>name</key>
-			<string>punctuation.section.property-list.end.stylus</string>
+			<string>meta.brace.curly</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\(|\)</string>
+			<key>name</key>
+			<string>meta.brace.round</string>
 		</dict>
 	</array>
 	<key>scopeName</key>


### PR DESCRIPTION
### Variable assignment

Now has the proper scope, will work for the correct characters, inside property definitions and with the `:=` and `?=` operators. 
### At-rules, properties

`@rule-here` for at-rules reworked. The previous `keyword.stylus` is changed to `keyword.at-rule.stylus` and applies only when matched when it's on its own, so that `@property-here` variables will be un-highlighted. The `@` in such instances is given `variable.punctuation.assignment`
### Constants

Put `true` `false` `defined` and `null` into `constant.language.stylus` scope (like in javascript) from the `keyword` scope
### Fixes

Some scopes were incorrect, such as `variable.language.stylus` for assignments
`meta.function.stylus` was being applied to `(`.
`()` are granted `meta.brace.round` scope
`{}` are changed to `meta.brace.curly` scope
`?` added to operators scope, considering `true ? 1 : 0` syntax

![Image](http://i.imgur.com/BTMl4.png)

[Reference](http://learnboost.github.com/stylus/docs/variables.html)
