### PR TITLE
Highlight selectors start with "+"(adjacent sibling selector).

### DIFF
--- a/Stylus.language.yml
+++ b/Stylus.language.yml
@@ -659,7 +659,7 @@ patterns:
 
                 ) | (
                                         # Property can't start with these
-                    [:~&gt;\[*]         # symbols but they are valid for selector
+                    [:~+&gt;\[*]         # symbols but they are valid for selector
                                         # so use it as a recognition rule
 
                 ) | (                   # for animtions

--- a/Stylus.tmLanguage
+++ b/Stylus.tmLanguage
@@ -1546,7 +1546,7 @@
         \s*([\s,.#\[]|:[^\s]|(?=\{))
 
     ) | (
-        [:~&gt;\[*]         # symbols but they are valid for selector
+        [:~+&gt;\[*]         # symbols but they are valid for selector
 
     ) | (                   # for animtions
 

--- a/highlight-test.stylus
+++ b/highlight-test.stylus
@@ -112,6 +112,17 @@ body
     color black
   }
 
+// Selectors start with a symbol
+div
+  :before
+  ::before
+  ~ div
+  + div
+  > div
+  [href^="#"]
+  *
+    background-color: red
+
 // Compound selectors
 body.someclass#someid
   font normal 18px/30px OpenSans, Verdana, sans-serif


### PR DESCRIPTION
before:
![before](https://cloud.githubusercontent.com/assets/3435149/3812358/4fd92ff6-1ca9-11e4-8c13-ddd5a8d50ac9.png)

after:
![after](https://cloud.githubusercontent.com/assets/3435149/3812362/53ddf870-1ca9-11e4-92f9-be3a1363146a.png)
