### PR TITLE
grammar: Escape ampersands

### DIFF
--- a/Stylus.language.yml
+++ b/Stylus.language.yml
@@ -527,9 +527,9 @@ repository:
             -   # Reference to parent selector including custom interpolation
                 match: |
                     (?x)            # multi-line regex definition mode
-                    ([\w\d_-]+)?    # matching any word right before &
-                    (&amp;)         # & itself, escaped because of plist
-                    ([\w\d_-]+)?    # matching any word right after &
+                    ([\w\d_-]+)?    # matching any word right before &amp;
+                    (&amp;)         # &amp; itself, escaped because of plist
+                    ([\w\d_-]+)?    # matching any word right after &amp;
                 captures:
                     1: { name: entity.other.attribute-name.stylus }
                     2: { name: variable.language.stylus }
@@ -744,9 +744,9 @@ patterns:
 
                 ) | (                   # Reference to parent
 
-                    ([\w\d_-]+)?        # matching any word right before &
-                    (&amp;)             # & itself, escaped because of plist
-                    ([\w\d_-]+)?        # matching any word right after &
+                    ([\w\d_-]+)?        # matching any word right before &amp;
+                    (&amp;)             # &amp; itself, escaped because of plist
+                    ([\w\d_-]+)?        # matching any word right after &amp;
                 )
             )
         patterns:

--- a/Stylus.tmLanguage
+++ b/Stylus.tmLanguage
@@ -1282,9 +1282,9 @@
           <dict>
             <key>match</key>
             <string>(?x)            # multi-line regex definition mode
-([\w\d_-]+)?    # matching any word right before &
-(&amp;)         # & itself, escaped because of plist
-([\w\d_-]+)?    # matching any word right after &
+([\w\d_-]+)?    # matching any word right before &amp;
+(&amp;)         # &amp; itself, escaped because of plist
+([\w\d_-]+)?    # matching any word right after &amp;
 </string>
             <key>captures</key>
             <dict>
@@ -1628,9 +1628,9 @@
 
     ) | (                   # Reference to parent
 
-        ([\w\d_-]+)?        # matching any word right before &
-        (&amp;)             # & itself, escaped because of plist
-        ([\w\d_-]+)?        # matching any word right after &
+        ([\w\d_-]+)?        # matching any word right before &amp;
+        (&amp;)             # &amp; itself, escaped because of plist
+        ([\w\d_-]+)?        # matching any word right after &amp;
     )
 )
 </string>


### PR DESCRIPTION
Hey there! As you may know, we use this Stylus package to provide syntax highlighting for Stylus files in GitHub.

I'm currently working on improving the way we load and perform syntax highlighting on the website, and I've noticed that there's an issue in the existing grammar which is chocking our new parser.

Specifically: the `&` character, even when inside a regexp comment, needs to be escaped as `&amp;`. This is a requirement for XML.

The proposed change fixes the issue in a backwards-compatible way. I'd appreciate if you could merge it. Thank you!